### PR TITLE
Correction de l'installation du projet

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-bundle": "^2.1",
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "doctrine/orm": "^2.7",
+        "ocramius/proxy-manager": "2.8.0",
         "phpdocumentor/reflection-docblock": "^5.2",
         "sensio/framework-extra-bundle": "^5.6",
         "symfony/asset": "5.1.*",


### PR DESCRIPTION
Ajout manuel de la dépendance 'ocramium/proxy-manager:2.8.0' pour voir installer doctrine/migrations